### PR TITLE
add macros for nicer syntax

### DIFF
--- a/macros/index.js
+++ b/macros/index.js
@@ -1,0 +1,39 @@
+
+unaryop (<-) 49 {
+  macro {
+    case { $ctx $channel:expr } => {
+      letstx $csp = [makeIdent('csp', #{$ctx})];
+      return #{ yield $csp.take($channel) }
+    }
+  }
+}
+
+binaryop (<-) 50 right {
+  macro {
+    case { $ctx $value $channel } => {
+      letstx $csp = [makeIdent('csp', #{$ctx})];
+      return #{ yield $csp.put($channel, $value) }
+    }
+  }
+}
+
+macro (<-alts) {
+  case { $ctx } => {
+    letstx $csp = [makeIdent('csp', #{$ctx})];
+    return #{ yield $csp.alts }
+  }
+}
+
+let go = macro {
+  case { $ctx ({ $code ... }) } => {
+    letstx $csp = [makeIdent('csp', #{$ctx})];
+    return #{ $csp.go(function*() { $code ... }) };
+  }
+  case { $ctx } => {
+    return #{ go }
+  }
+}
+
+export (<-);
+export (<-alts);
+export go;


### PR DESCRIPTION
This adds a small file which sweet.js users can load to get awesome syntax. This doesn't affect people who don't use sweet.js at all. Look at how nice this can look now: https://gist.github.com/jlongster/57ad73756529a5dcc4de
