### PR TITLE
basic transducer support

### DIFF
--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -25,7 +25,7 @@ function go(f, args) {
   return spawn(gen);
 };
 
-function chan(bufferOrNumber) {
+function chan(bufferOrNumber, xform, exHandler) {
   var buf;
   if (bufferOrNumber === 0) {
     bufferOrNumber = null;
@@ -35,7 +35,7 @@ function chan(bufferOrNumber) {
   } else {
     buf = bufferOrNumber;
   }
-  return channels.chan(buf);
+  return channels.chan(buf, xform, exHandler);
 };
 
 


### PR DESCRIPTION
Here is the initial transducers support that I had before, but updated to work with the new transducer interface. Cognitect has released their own JS transducer library, but this should be interoperable. It feels like eventually we may want a basic transducer spec for JS...

I don't check if the value is `Reduced` yet, which I think should close the channel? That is the only weird part; right now you have to add a dependency to my transducers lib and do a `x instanceof Reduced` check. We should probably figure out how to standardize this check; maybe a toString() on the object returns `[object Reduced]` or something, though that would be slow. There is some talk about that here https://github.com/jlongster/transducers.js/issues/2
