### PR TITLE
don't require callback for putAsync (fixes #16)

### DIFF
--- a/src/impl/process.js
+++ b/src/impl/process.js
@@ -18,7 +18,7 @@ FnHandler.prototype.commit = function() {
 
 function put_then_callback(channel, value, callback) {
   var result = channel._put(value, new FnHandler(callback));
-  if (result) {
+  if (result && callback) {
     callback(result.value);
   }
 }


### PR DESCRIPTION
We shouldn't require users to provide a callback for `putAsync`
