### PR TITLE
commit the handler when putting on a closed channel

### DIFF
--- a/src/impl/channels.js
+++ b/src/impl/channels.js
@@ -38,6 +38,7 @@ Channel.prototype._put = function(value, handler) {
   }
 
   if (this.closed || !handler.is_active()) {
+    handler.commit();
     return new Box(!this.closed);
   }
 


### PR DESCRIPTION
Shouldn't we call commit here? That way a `put` on a closed channel is a valid `alts` operation.
