### PR TITLE
keep track of the original generator function for debugging

### DIFF
--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -6,7 +6,7 @@ var select = require("./impl/select");
 var process = require("./impl/process");
 var timers = require("./impl/timers");
 
-function spawn(gen) {
+function spawn(gen, creator) {
   var ch = channels.chan(buffers.fixed(1));
   (new process.Process(gen, function(value) {
     if (value === channels.CLOSED) {
@@ -16,13 +16,13 @@ function spawn(gen) {
         ch.close();
       });
     }
-  })).run();
+  }, creator)).run();
   return ch;
 };
 
 function go(f, args) {
   var gen = f.apply(null, args);
-  return spawn(gen);
+  return spawn(gen, f);
 };
 
 function chan(bufferOrNumber, xform, exHandler) {

--- a/src/impl/process.js
+++ b/src/impl/process.js
@@ -30,8 +30,9 @@ function take_then_callback(channel, callback) {
   }
 }
 
-var Process = function(gen, onFinish) {
+var Process = function(gen, onFinish, creator) {
   this.gen = gen;
+  this.creatorFunc = creator;
   this.finished = false;
   this.onFinish = onFinish;
 };


### PR DESCRIPTION
I'm developing a Firefox devtool addon that is a channel debugger. It graphs a timeline of events by instrumenting the code with breakpoints using our debugger API. It's coming along really well.

The one thing that I haven't been able to do is accurately name each process. I can do it within `go` (set a breakpoint there, inspect the function passed in, get the name of it). But that doesn't work if a process is currently running and then you press "record"; it will get events from a process but because we only have a generator instance I have no idea what name of the original function is.

I propose this simple change which will greatly help with the debugger. I can't think of any implications of this; possibly the function won't be garbage collected until the process dies but I bet that happens anyway with generators.

Here's a screenshot for fun (lots more to do):

![screen shot 2014-10-29 at 6 36 27 pm](https://cloud.githubusercontent.com/assets/17031/4835944/05e26668-5fbd-11e4-8cf2-fc5003dc96c9.png)
