### PR TITLE
Don't block split channels

### DIFF
--- a/src/csp.operations.js
+++ b/src/csp.operations.js
@@ -173,7 +173,9 @@ function split(p, ch, trueBufferOrN, falseBufferOrN) {
         fch.close();
         break;
       }
-      yield put(p(value) ? tch : fch, value);
+      go(function*() {
+        yield put(p(value) ? tch : fch, value);
+      });
     }
   });
   return [tch, fch];


### PR DESCRIPTION
When splitting channels, putting a value on one channel currently blocks the other channel until the value is taken off it.  Moving it into its own go callback prevents one channel from blocking the other.