### PR TITLE
remove arguments option in `go`

### DIFF
--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -6,9 +6,10 @@ var select = require("./impl/select");
 var process = require("./impl/process");
 var timers = require("./impl/timers");
 
-function spawn(gen, creator) {
+function spawn(gen, opts, creator) {
+  opts = opts || {};
   var ch = channels.chan(buffers.fixed(1));
-  (new process.Process(gen, function(value) {
+  (new process.Process(gen, opts, function(value) {
     if (value === channels.CLOSED) {
       ch.close();
     } else {
@@ -20,9 +21,9 @@ function spawn(gen, creator) {
   return ch;
 };
 
-function go(f, args) {
-  var gen = f.apply(null, args);
-  return spawn(gen, f);
+function go(f, opts) {
+  opts = opts || {};
+  return spawn(f(), opts, f);
 };
 
 function chan(bufferOrNumber, xform, exHandler) {

--- a/src/csp.operations.js
+++ b/src/csp.operations.js
@@ -4,6 +4,7 @@ var Box = require("./impl/channels").Box;
 
 var csp = require("./csp.core"),
     go = csp.go,
+    spawn = csp.spawn,
     take = csp.take,
     put = csp.put,
     takeAsync = csp.takeAsync,
@@ -134,13 +135,13 @@ function* mapcat(f, src, dst) {
 
 function mapcatFrom(f, ch, bufferOrN) {
   var out = chan(bufferOrN);
-  go(mapcat, [f, ch, out]);
+  spawn(mapcat(f, ch, out));
   return out;
 }
 
 function mapcatInto(f, ch, bufferOrN) {
   var src = chan(bufferOrN);
-  go(mapcat, [f, src, ch]);
+  spawn(mapcat(f, src, ch))
   return src;
 }
 

--- a/src/csp.test-helpers.js
+++ b/src/csp.test-helpers.js
@@ -22,7 +22,7 @@ function identity_chan(x) {
 // }));
 function g(f) {
   return function(done) {
-    go(f, [done]);
+    csp.spawn(f(done));
   };
 };
 

--- a/src/impl/process.js
+++ b/src/impl/process.js
@@ -30,7 +30,7 @@ function take_then_callback(channel, callback) {
   }
 }
 
-var Process = function(gen, onFinish, creator) {
+var Process = function(gen, opts, onFinish, creator) {
   this.gen = gen;
   this.creatorFunc = creator;
   this.finished = false;

--- a/test/csp.js
+++ b/test/csp.js
@@ -299,9 +299,9 @@ describe("alts", function() {
 
 describe("Goroutine", function() {
   it("should put returned value on output channel and close it", function*() {
-    var ch = go(function*(x) {
-      return x;
-    }, [42]);
+    var ch = go(function*() {
+      return 42;
+    });
     var value = yield take(ch);
     assert.equal(value, 42, "returned value is delivered");
     assert.equal(ch.is_closed(), true, "output channel is closed");


### PR DESCRIPTION
I have a good proposal for error handling I think, but one thing that it does is gives you the ability to configure a `go` block to automatically propagate. I don't think we should add tons of options to go functions, but this is useful enough to merit it. It should look like:

``` js
go(function*() {
  // ....
}, { propagate: true });
```

Right now you'd always have to pass an empty array as the second argument. I've always found that argument redundant though since we have `spawn`. Either just use those variables directly in the go block, or use spawn to call the generator with the args, like `spawn(gen(arg1, arg2))`. In the rare case that you need to use this with a new function, just do `spawn((function*(x, y, z) { ... })(x, y, z))`.

Removing this gives us the ability to add the above option (which I will go into more details in the errors PR), without removing hardly any functionality. What do you think?
