### PR TITLE
Fix `go` function for IE8-

### DIFF
--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -21,6 +21,8 @@ function spawn(gen, creator) {
 };
 
 function go(f, args) {
+  args = args || [];
+
   var gen = f.apply(null, args);
   return spawn(gen, f);
 };


### PR DESCRIPTION
This PR fixes IE8- compatibility of `go` function. `Function.prototype.apply` needs the second parameter to be an array. This didn't even throw an error which I think it should, looks like it was swallowed by something.

This could be solved by #24, which I'm all for - we can use `spawn` for generators with params directly.