### PR TITLE
Fix `mix` operation so it properly handles solos and mutes

### DIFF
--- a/src/csp.operations.js
+++ b/src/csp.operations.js
@@ -622,7 +622,7 @@ function mix(out) {
       }
       var solos = state.solos;
       if (solos.indexOf(channel) > -1 ||
-          (solos.length && !(m.mutes.indexOf(channel) > -1))) {
+          (solos.length === 0 && !(state.mutes.indexOf(channel) > -1))) {
         var stillOpen = yield put(out, value);
         if (!stillOpen) {
           break;

--- a/test/operations.js
+++ b/test/operations.js
@@ -301,10 +301,26 @@ describe("Operations", function() {
   });
 
   describe("mix", function() {
+    var in1;
+    var in2;
+    var out;
+    var take_out;
+    var mixer;
+
+    // Common data for `mix` tests.
+    beforeEach(function*() {
+      in1 = ops.fromColl([1, 2, 3]);
+      in2 = ops.fromColl([4, 5, 6]);
+      out = chan();
+      take_out = chan();
+
+      mixer = ops.mix(out);
+    });
+
     it("should work", function*() {
-      var out = chan();
-      var m = ops.mix(out);
-      var take_out = chan();
+      mixer.admix(in1);
+      mixer.admix(in2);
+
       go(function*() {
         for (var i = 0; i < 6; i++) {
           var value = yield take(out);
@@ -312,11 +328,7 @@ describe("Operations", function() {
         }
         take_out.close();
       });
-      var in1 = ops.fromColl([1, 2, 3]);
-      var in2 = ops.fromColl([4, 5, 6]);
-      ops.mix.add(m, in1);
-      ops.mix.add(m, in2);
-      ops.mix.toggle(m, [[in1, {solo: true}], [in2, {solo: true}]]);
+
       assert.deepEqual(
         [1, 2, 3, 4, 5, 6],
         (yield take(ops.into([], take_out))).sort()

--- a/test/operations.js
+++ b/test/operations.js
@@ -334,6 +334,46 @@ describe("Operations", function() {
         (yield take(ops.into([], take_out))).sort()
       );
     });
+
+    describe("#toggle", function() {
+      it("should solo", function*() {
+        mixer.admix(in1);
+        mixer.admix(in2);
+        mixer.toggle([[in1, {solo: true}]]);
+
+        go(function*() {
+          for (var i = 0; i < 3; i++) {
+            var value = yield take(out);
+            yield put(take_out, value);
+          }
+          take_out.close();
+        });
+
+        assert.deepEqual(
+          [1, 2, 3],
+          (yield take(ops.into([], take_out))).sort()
+        );
+      });
+
+      it("should mute", function*() {
+        mixer.admix(in1);
+        mixer.admix(in2);
+        mixer.toggle([[in1, {mute: true}]]);
+
+        go(function*() {
+          for (var i = 0; i < 3; i++) {
+            var value = yield take(out);
+            yield put(take_out, value);
+          }
+          take_out.close();
+        });
+
+        assert.deepEqual(
+          [4, 5, 6],
+          (yield take(ops.into([], take_out))).sort()
+        );
+      });
+    });
   });
 
   describe("pub-sub", function() {


### PR DESCRIPTION
Previously, due to incorrect `if` statement, if there were no `solos` (array had `length` of `0`), nothing could went through.

Additionally, `m.mutes` is undefined, the `mutes` are on the `state` object.