### PR TITLE
added goloop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-csp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "CSP channels with ES6 generators, inspired by Clojurescript's core.async and Go",
   "keywords": [
     "csp", "async", "concurrency", "channel",

--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -27,6 +27,22 @@ function go(f, args) {
   return spawn(gen, f);
 };
 
+function goloop(f, args) {
+  var recurring;
+  var recur = function() {
+    args = Array.prototype.slice.call(arguments);
+    args.unshift(recur);
+    recurring = true;
+  }
+  recur.apply(null, args);
+  return go(function* () {
+    while (recurring) {
+      recurring = false;
+      yield* f.apply(null, args);
+    }
+  });
+};
+
 function chan(bufferOrNumber, xform, exHandler) {
   var buf;
   if (bufferOrNumber === 0) {
@@ -50,6 +66,7 @@ module.exports = {
 
   spawn: spawn,
   go: go,
+  goloop: goloop,
   chan: chan,
   DEFAULT: select.DEFAULT,
   CLOSED: channels.CLOSED,

--- a/test/csp.js
+++ b/test/csp.js
@@ -8,6 +8,7 @@ var a = require("../src/csp.test-helpers"),
 var csp = require("../src/csp"),
     chan = csp.chan,
     go = csp.go,
+    goloop = csp.goloop,
     put = csp.put,
     take = csp.take,
     putAsync = csp.putAsync,
@@ -364,6 +365,27 @@ describe("Goroutine", function() {
     }, [CLOSED]);
     var value = yield take(ch);
     assert.equal(value, CLOSED, "CLOSED is delivered");
+    assert.equal(ch.is_closed(), true, "output channel is closed");
+  });
+});
+
+describe("Goloop", function() {
+  var iterations = 1000;
+  it("should write to channel "+iterations+" times and close it", function*() {
+    var ch = chan();
+    goloop(function*(recur, i) {
+      if (i < iterations) {
+        yield put(ch, i);
+        recur(i+1);
+      } else {
+        ch.close();
+      }
+    }, [0]);
+    var values = [];
+    while ((value = yield take(ch)) !== CLOSED) {
+      values.push(value);
+    }
+    assert.equal(values.length, iterations, "returned 10 values");
     assert.equal(ch.is_closed(), true, "output channel is closed");
   });
 });


### PR DESCRIPTION
I kept putting `for (;;) { }` loops in my "go blocks", so I thought I'd give "goloop" a shot.  There's a test too.  Not sure if there's a better way to handle the nested generator than `yield*`.  Passing `recur` seemed like a nice way to decide when to exit while also letting the caller determine their next args.

I'm not really sure what the channel returned from `go` is for.  Maybe there's a better solution there.

Thoughts?