### PR TITLE
Add more explanations and examples to the basic documentation

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -1,30 +1,103 @@
 ## Channels ##
 
-These are *not* constructor functions. Don't use `new`.
+Message passing between processes happens via channels. Channels can have many writers and readers,
+which can do put and get operations on them putting or getting a single value at a time.
+
+The following functions are *not* constructor functions. Don't use `new`.
 
 ### `chan(bufferOrN?, transducer?, exHandler?)` ###
 
-Creates a channel with an optional buffer, an optional transducer, and optional exception handler.
+Creates a channel with an optional buffer, an optional transducer, and optional exception handler. We'll
+elaborate more on them later on.
 
-If no argument is passed, the channel is unbuffered (synchronization).
+If no argument is passed, the channel is unbuffered. This means that putters will "wait" for takers
+and viceversa (synchronization).
+
+We can put and take values asynchronously from a channel:
+```javascript
+var ch = csp.chan();
+
+csp.takeAsync(ch, function(value) { return console.log("Got ", value); });
+
+// After the put, the pending take will happen
+csp.putAsync(ch, 42);
+//=> "Got 42"
+```
+
+Puts and takes can happen in any order:
+```javascript
+var ch = csp.chan();
+
+// Async puts accept a callback too
+csp.putAsync(ch, 42, function(){ console.log("Just put 42"); });
+csp.putAsync(ch, 43, function(){ console.log("One more"); });
+
+csp.takeAsync(ch, function(value) { console.log("Got ", value); })
+//=> "Got 42"
+//=> "Just put 42"
+csp.takeAsync(ch, function(value) { console.log("Got ", value); })
+//=> "Got 43"
+//=> "One more"
+```
 
 `bufferOrN`:
 - If a number is passed, the channel is backed by a fixed buffer of that size (bounded asynchronization).
 - If a buffer is passed, the channel is backed by that buffer (bounded asynchronization).
 
-If a transducer is specified, the channel must be buffered. When an error is thrown during transformation, `exHandler` will be called with the error as the argument, and any non-`CLOSED` return value will be put into the channel. If `exHandler` is not specified, a default handler that logs the error and returns `CLOSED` will be used.
-
 ### `buffers.fixed(n)` ###
 
 Creates a fixed buffer of size n. When full, puts will "block".
 
+This is the default buffer that is created when calling `chan` with a number as its buffer argument.
+
 ### `buffers.dropping(n)` ###
 
 Creates a dropping buffer of size n. When full, puts will not "block", but the value is discarded.
+```javascript
+var ch = csp.chan(csp.buffers.dropping(1));
+
+csp.putAsync(ch, 42);
+csp.putAsync(ch, 43); // will be dropped!
+
+csp.takeAsync(ch, function(v) { console.log("Got ", v) });
+//=> "Got 42"
+csp.takeAsync(ch); // will "block"
+```
 
 ### `buffers.sliding(n)` ###
 
 Creates a sliding buffer of size n. When full, puts will not "block", but the oldest value is discarded.
+```javascript
+var ch = csp.chan(csp.buffers.sliding(1));
+
+csp.putAsync(ch, 41);
+csp.putAsync(ch, 42);
+
+csp.takeAsync(ch, function(v) { console.log("Got ", v) });
+//=> "Got 42"
+csp.takeAsync(ch); // will "block"
+```
+
+### Transducers
+
+If a [transducer](https://github.com/jlongster/transducers.js) is specified, the channel must be buffered. When an error is thrown during transformation, `exHandler` will be called with the error as the argument, and any non-`CLOSED` return value will be put into the channel. If `exHandler` is not specified, a default handler that logs the error and returns `CLOSED` will be used.
+```javascript
+var xducers = require("transducers-js");
+
+// transducers execute from left to right when composed
+var xform = xducers.comp(
+          xducers.filter((v) => v !== 42),
+          xducers.map((v) => v + 1)
+    ),
+    ch = csp.chan(2, xform);
+
+csp.putAsync(ch, 42, function(){ console.log("Won't happen")});
+
+csp.takeAsync(ch, function(value) { console.log("Got ", value)});
+csp.putAsync(ch, 41, function(){ console.log("Just put 41")});
+//=> "Got 42"
+//=> "Just put 41"
+```
 
 ### `timeout(msecs)` ###
 
@@ -36,6 +109,9 @@ Creates an unbuffered channel that will be closed after `msecs` milliseconds.
 
 Spawns a "goroutine" from the supplied generator function, and arguments.
 Returns a channel that will receive the value returned by the goroutine.
+
+The `yield` keyword can be used for doing take and put operations on a channel.
+Yielding a channel is an implicit take.
 ```javascript
 // Spawn a goroutine, and immediately return a channel
 var ch = csp.go(function*(x) {
@@ -93,10 +169,28 @@ Completes at most one of the channel operations. Each operation is either a chan
 "Returns" an object with 2 properties: The `channel` of the succeeding operation, and the `value` returned by the corresponding `put`/`take` operation.
 - If no operation is ready:
   + If `options.default` is specified, "returns" `{value: options.default, channel: csp.DEFAULT}`.
-  + Otherwise blocks until the an operation completes.
+  + Otherwise blocks until an operation completes.
 - If more than one operation is ready:
   + If `options.priority` is `true`, tries the operations in order.
   + Otherwise makes a non-deterministic choice.
+
+Here's a simple example using a timeout channel for canceling an operation after a certain
+amount of time:
+```javascript
+var ch = csp.chan();
+
+csp.go(function*(){
+    yield csp.timeout(1000);
+    yield csp.put(ch, 42);
+});
+
+csp.go(function*(){
+    var cancel = csp.timeout(300),
+        result = yield csp.alts([ch, cancel]);
+    console.log("Has been cancelled?", result.channel === cancel);
+});
+//=> "Has been cancelled? true"
+```
 
 ### `yield sleep(msecs)` ###
 


### PR DESCRIPTION
First of all thanks for writing this library, it's great to be able to use CSP in JavaScript.

I added a gentler introduction in the basic docs trying to explain the concepts better, it's not that
the documentation is bad but is more of an API reference. I think it'd be great to write even more
examples so people can understand better the value proposition of CSP.

If you think these changes are worth it I'd be happy to do further work on examples for the basic
and advanced documentation.

You can see a [preview](https://github.com/dialelo/js-csp/blob/master/doc/basic.md) in my fork.