### PR TITLE
add babelify transform for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
     "email": "ubolonton@gmail.com",
     "url": "https://github.com/ubolonton/js-csp/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "babelify": "^5.0.3"
+  },
+  "browserify": {
+    "transform": ["babelify"]
+  },
   "devDependencies": {
     "browserify": "^6.0.2",
     "chai": "~1.9.0",


### PR DESCRIPTION
When requiring this file with browserify, the babelify transform should be applied automatically to transpile ES6 to ES5.