### PR TITLE
slighty tweak internal code so CSP debugger can consistently access scope

### DIFF
--- a/src/impl/channels.js
+++ b/src/impl/channels.js
@@ -75,8 +75,8 @@ Channel.prototype._put = function(value, handler) {
         break;
       }
       if (taker.is_active()) {
-        callback = taker.commit();
         value = this.buf.remove();
+        callback = taker.commit();
         schedule(callback, value);
       }
     }
@@ -161,6 +161,7 @@ Channel.prototype._take = function(handler) {
   // for that).
   while (true) {
     putter = this.puts.pop();
+    value = putter.value;
     if (putter === buffers.EMPTY) {
       break;
     }
@@ -170,7 +171,7 @@ Channel.prototype._take = function(handler) {
       if (callback) {
         schedule(callback, true);
       }
-      return new Box(putter.value);
+      return new Box(value);
     }
   }
 


### PR DESCRIPTION
Finally starting to get back into things :)

Basically my CSP debugger is an addon that sets breakpoints that, when hit, inspect the stack and pull out information about the current process. I need to have consistent access to what `value` is in this frame.