### PR TITLE
Promise channel

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -78,6 +78,28 @@ csp.takeAsync(ch, function(v) { console.log("Got ", v) });
 csp.takeAsync(ch); // will "block"
 ```
 
+### `buffers.promise()` ###
+
+Creates a promise buffer. A promise buffer can take exactly one value that all consumers will receive. Once the
+firt value is put, subsequent puts will succeed but the items will be dropped.
+```javascript
+var ch = csp.chan(csp.buffers.promise());
+
+csp.putAsync(ch, 42);
+csp.putAsync(ch, "Will be discarded");
+
+csp.takeAsync(ch, function(v) { console.log("Got ", v) });
+//=> "Got 42"
+csp.takeAsync(ch, function(v) { console.log("Got ", v) });
+//=> "Got 42"
+csp.takeAsync(ch, function(v) { console.log("Got ", v) });
+//=> "Got 42"
+
+ch.close();
+csp.takeAsync(ch, function(v) { console.log(ch === csp.CLOSED); });
+//=> "true"
+```
+
 ### Transducers
 
 If a [transducer](https://github.com/jlongster/transducers.js) is specified, the channel must be buffered. When an error is thrown during transformation, `exHandler` will be called with the error as the argument, and any non-`CLOSED` return value will be put into the channel. If `exHandler` is not specified, a default handler that logs the error and returns `CLOSED` will be used.

--- a/doc/basic.md
+++ b/doc/basic.md
@@ -82,8 +82,10 @@ csp.takeAsync(ch); // will "block"
 
 Creates a promise buffer. A promise buffer can take exactly one value that all consumers will receive. Once the
 firt value is put, subsequent puts will succeed but the items will be dropped.
+
+For creating channels with promise buffers a `promiseChan(transducer?, exHandler?)` convenience function is provided.
 ```javascript
-var ch = csp.chan(csp.buffers.promise());
+var ch = csp.promiseChan(); // equivalent to csp.chan(csp.buffers.promise())
 
 csp.putAsync(ch, 42);
 csp.putAsync(ch, "Will be discarded");

--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -45,7 +45,8 @@ module.exports = {
   buffers: {
     fixed: buffers.fixed,
     dropping: buffers.dropping,
-    sliding: buffers.sliding
+    sliding: buffers.sliding,
+    promise: buffers.promise
   },
 
   spawn: spawn,

--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -40,6 +40,10 @@ function chan(bufferOrNumber, xform, exHandler) {
   return channels.chan(buf, xform, exHandler);
 };
 
+function promiseChan(xform, exHandler){
+    return chan(buffers.promise(), xform, exHandler);
+};
+
 
 module.exports = {
   buffers: {
@@ -52,6 +56,7 @@ module.exports = {
   spawn: spawn,
   go: go,
   chan: chan,
+  promiseChan: promiseChan,
   DEFAULT: select.DEFAULT,
   CLOSED: channels.CLOSED,
 

--- a/src/impl/buffers.js
+++ b/src/impl/buffers.js
@@ -14,6 +14,8 @@ function acopy(src, src_start, dst, dst_start, length) {
   }
 }
 
+function noop() {};
+
 var EMPTY = {
   toString: function() {
     return "[object EMPTY]";
@@ -91,6 +93,8 @@ RingBuffer.prototype.cleanup = function(predicate) {
   }
 };
 
+RingBuffer.prototype.close = noop;
+
 var FixedBuffer = function(buf,  n) {
   this.buf = buf;
   this.n = n;
@@ -114,6 +118,7 @@ FixedBuffer.prototype.count = function() {
   return this.buf.length;
 };
 
+FixedBuffer.prototype.close = noop;
 
 var DroppingBuffer = function(buf, n) {
   this.buf = buf;
@@ -138,6 +143,7 @@ DroppingBuffer.prototype.count = function() {
   return this.buf.length;
 };
 
+DroppingBuffer.prototype.close = noop;
 
 var SlidingBuffer = function(buf, n) {
   this.buf = buf;
@@ -163,6 +169,35 @@ SlidingBuffer.prototype.count = function() {
   return this.buf.length;
 };
 
+SlidingBuffer.prototype.close = noop;
+
+var PromiseBuffer = function PromiseBuffer() {
+    this.val = EMPTY;
+};
+
+PromiseBuffer.prototype.count = function() {
+    return (this.val === EMPTY) ? 0 : 1;
+};
+
+PromiseBuffer.prototype.add = function(item) {
+    if (this.val === EMPTY) {
+        this.val = item;
+    }
+};
+
+PromiseBuffer.prototype.is_full = function() {
+    return false;
+};
+
+PromiseBuffer.prototype.remove = function() {
+    if (this.val !== EMPTY) {
+        return this.val;
+    }
+};
+
+PromiseBuffer.prototype.close = function() {
+    this.val = EMPTY;
+};
 
 var ring = exports.ring = function ring_buffer(n) {
   return new RingBuffer(0, 0, 0, new Array(n));
@@ -186,6 +221,10 @@ exports.dropping = function dropping_buffer(n) {
 
 exports.sliding = function sliding_buffer(n) {
   return new SlidingBuffer(ring(n), n);
+};
+
+exports.promise = function promise_buffer() {
+  return new PromiseBuffer();
 };
 
 exports.EMPTY = EMPTY;

--- a/src/impl/channels.js
+++ b/src/impl/channels.js
@@ -203,6 +203,7 @@ Channel.prototype.close = function() {
 
   // TODO: Duplicate code. Make a "_flush" function or something
   if (this.buf) {
+    this.buf.close();
     this.xform.result(this.buf);
     while (true) {
       if (this.buf.count() === 0) {

--- a/test/buffers.js
+++ b/test/buffers.js
@@ -91,3 +91,32 @@ describe("Sliding buffer", function() {
     assert(buffers.EMPTY === b.remove(), "popping empty buffer gives EMPTY");
   });
 });
+
+describe("Promise buffer", function() {
+  it("should work", function() {
+    var b = buffers.promise();
+    assert.equal(b.count(), 0, "new buffer is empty");
+
+    b.add("1");
+    assert.equal(b.count(), 1);
+
+    b.add("2");
+    assert.equal(b.count(), 1, "promise buffer drops puts after the first one");
+    assert.equal(b.is_full(), false, "promise buffer is never full");
+    assert.doesNotThrow(function() {
+      b.add("3");
+    }, "promise buffer always accepts push");
+    assert.equal(b.count(), 1);
+
+    assert.equal(b.remove(), "1", "promise buffer always returns oldest item");
+    assert.equal(b.is_full(), false);
+    assert.equal(b.count(), 1);
+
+    assert.equal(b.remove(), "1", "promise buffer keeps returning oldest item");
+    assert.equal(b.is_full(), false);
+    assert.equal(b.count(), 1);
+
+    b.close();
+    assert.equal(b.remove(), null, "promise buffer returns null after closing it");
+  });
+});

--- a/test/csp.js
+++ b/test/csp.js
@@ -7,6 +7,7 @@ var a = require("../src/csp.test-helpers"),
 
 var csp = require("../src/csp"),
     chan = csp.chan,
+    promiseChan = csp.promiseChan,
     go = csp.go,
     put = csp.put,
     take = csp.take,
@@ -37,6 +38,13 @@ describe("put", function() {
       var ch = chan();
       ch.close();
       assert.equal((yield put(ch, 42)), false);
+    });
+
+    it("should always return true when putting to a promise channel", function*() {
+      var ch = promiseChan();
+      assert.equal((yield put(ch, 42)), true);
+      assert.equal((yield put(ch, 43)), true);
+      assert.equal((yield put(ch, 44)), true);
     });
   });
 
@@ -69,6 +77,15 @@ describe("put", function() {
 
     //   assert.equal(buffered, true, "pending put is buffered once the buffer is not full again");
     // });
+
+    it("should return true if value is then taken from promise channel", function*() {
+      var ch = promiseChan();
+      go(function*() {
+        yield timeout(5);
+        yield take(ch);
+      });
+      assert.equal((yield put(ch, 42)), true);
+    });
 
     it("should return false if channel is then closed", function*() {
       var ch = chan();
@@ -132,8 +149,20 @@ describe("take", function() {
       assert.equal((yield take(ch)), 42);
     });
 
+    it("should return correct value that was first put in promise channel", function*() {
+      var ch = promiseChan();
+      yield put(ch, 42);
+      assert.equal((yield take(ch)), 42);
+    });
+
     it("should return false if channel is already closed", function*() {
       var ch = chan();
+      ch.close();
+      assert.equal((yield take(ch)), CLOSED);
+    });
+
+    it("should return false if promise channel is already closed", function*() {
+      var ch = promiseChan();
       ch.close();
       assert.equal((yield take(ch)), CLOSED);
     });
@@ -149,8 +178,31 @@ describe("take", function() {
       assert.equal((yield take(ch)), 42);
     });
 
+    it("should return correct value if it is then delivered to promise channel", function*() {
+      var ch = promiseChan();
+      go(function*() {
+        yield timeout(5);
+        yield put(ch, 42);
+        yield put(ch, 43);
+        yield put(ch, 44);
+      });
+      assert.equal((yield take(ch)), 42);
+      assert.equal((yield take(ch)), 42);
+    });
+
     it("should return CLOSED if channel is then closed", function*() {
       var ch = chan();
+
+      go(function*() {
+        yield timeout(5);
+        ch.close();
+      });
+
+      assert.equal((yield take(ch)), CLOSED);
+    });
+
+    it("should return CLOSED if promise channel is then closed", function*() {
+      var ch = promiseChan();
 
       go(function*() {
         yield timeout(5);
@@ -429,6 +481,30 @@ describe("close", function() {
 
   it("should correctly flush CLOSED to pending takes", function*() {
     var ch = chan();
+    var count = 0;
+
+    go(function*() {
+      assert.equal((yield take(ch)), CLOSED);
+      count += 1;
+      assert.equal(count, 1);
+    });
+    go(function*() {
+      assert.equal((yield take(ch)), CLOSED);
+      count += 1;
+      assert.equal(count, 2);
+    });
+    go(function*() {
+      assert.equal((yield take(ch)), CLOSED);
+      count += 1;
+      assert.equal(count, 3);
+    });
+
+    ch.close();
+    yield undefined;
+  });
+
+  it("should correctly flush CLOSED to pending takes from promise channel", function*() {
+    var ch = promiseChan();
     var count = 0;
 
     go(function*() {


### PR DESCRIPTION
This is a direct port of `core.async`'s promise channel. Combined with an update to `dePromiseify` in ubolonton/js-csp#37 may solve ubolonton/js-csp#13.