### PR TITLE
Expose Instruction

### DIFF
--- a/src/impl/process.js
+++ b/src/impl/process.js
@@ -155,5 +155,5 @@ exports.put = put;
 exports.take = take;
 exports.sleep = sleep;
 exports.alts = alts;
-
+exports.Instruction = Instruction;
 exports.Process = Process;


### PR DESCRIPTION
I know this doesn't help JS-CSP directly, but this is important for building any third-party runner for Channels.
I'm currently trying to build something like a go-runner with a kitchen sync approach. It will work with Channels, Promises, Observables (Rx, Bacon, Kefir), Node streams, and Thunks.

This will be impossible with access to Instruction. By own project may crash and burn, but this will still be important for any other tool that wants to support JS-CSP.