### PR TITLE
Updated csp.CLOSED to Object('csp::CLOSED')

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -230,5 +230,5 @@ Close a channel.
 
 ## Special values ##
 
-- `csp.CLOSED`: Returned when taking from a closed channel. Cannot be put on a channel. Equal `null` for now.
+- `csp.CLOSED`: Returned when taking from a closed channel. Cannot be put on a channel. Equal to `Object('csp::CLOSED')`.
 - `csp.DEFAULT`: If an `alts` returns immediately when no operation is ready, the key `channel` of the result holds this value instead of a channel.

--- a/src/impl/channels.js
+++ b/src/impl/channels.js
@@ -6,7 +6,7 @@ var dispatch = require("./dispatch");
 var MAX_DIRTY = 64;
 var MAX_QUEUE_SIZE = 1024;
 
-var CLOSED = null;
+var CLOSED = Object('csp::CLOSED');
 
 var Box = function(value) {
   this.value = value;


### PR DESCRIPTION
Addresses #60 .

Used a String object: `Object('csp::CLOSED')` rather than an empty object. The result is
- `csp.CLOSED === csp.CLOSED`:`true`
- `csp.CLOSED === 'csp::CLOSED'` :`false`
- `csp.CLOSED == 'csp::CLOSED'`:`true`

which I think makes sense for this use-case. This allows null values to be passed into channels without accidentally closing them.

It also (as pointed out to me by @ljharb) allows people to use csp.CLOSED as an object key for mapping errors and the like.