### PR TITLE
Revert promise channel

### DIFF
--- a/doc/basic.md
+++ b/doc/basic.md
@@ -78,29 +78,6 @@ csp.takeAsync(ch, function(v) { console.log("Got ", v) });
 csp.takeAsync(ch); // will "block"
 ```
 
-### `buffers.promise()` ###
-
-Creates a promise buffer. A promise buffer can take exactly one value that all consumers will receive. Once the
-first value is put, subsequent puts will succeed but the items will be dropped.
-
-For creating channels with promise buffers a `promiseChan(transducer?, exHandler?)` convenience function is provided.
-```javascript
-var ch = csp.promiseChan(); // equivalent to csp.chan(csp.buffers.promise())
-
-csp.putAsync(ch, 42);
-csp.putAsync(ch, "Will be discarded");
-
-csp.takeAsync(ch, function(v) { console.log("Got ", v) });
-//=> "Got 42"
-csp.takeAsync(ch, function(v) { console.log("Got ", v) });
-//=> "Got 42"
-csp.takeAsync(ch, function(v) { console.log("Got ", v) });
-//=> "Got 42"
-
-ch.close();
-csp.takeAsync(ch, function(v) { console.log(ch === csp.CLOSED); });
-//=> "true"
-```
 
 ### Transducers
 

--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -40,23 +40,17 @@ function chan(bufferOrNumber, xform, exHandler) {
   return channels.chan(buf, xform, exHandler);
 };
 
-function promiseChan(xform, exHandler){
-    return chan(buffers.promise(), xform, exHandler);
-};
-
 
 module.exports = {
   buffers: {
     fixed: buffers.fixed,
     dropping: buffers.dropping,
-    sliding: buffers.sliding,
-    promise: buffers.promise
+    sliding: buffers.sliding
   },
 
   spawn: spawn,
   go: go,
   chan: chan,
-  promiseChan: promiseChan,
   DEFAULT: select.DEFAULT,
   CLOSED: channels.CLOSED,
 

--- a/src/impl/buffers.js
+++ b/src/impl/buffers.js
@@ -14,8 +14,6 @@ function acopy(src, src_start, dst, dst_start, length) {
   }
 }
 
-function noop() {};
-
 var EMPTY = {
   toString: function() {
     return "[object EMPTY]";
@@ -116,7 +114,6 @@ FixedBuffer.prototype.count = function() {
   return this.buf.length;
 };
 
-FixedBuffer.prototype.close = noop;
 
 var DroppingBuffer = function(buf, n) {
   this.buf = buf;
@@ -141,7 +138,6 @@ DroppingBuffer.prototype.count = function() {
   return this.buf.length;
 };
 
-DroppingBuffer.prototype.close = noop;
 
 var SlidingBuffer = function(buf, n) {
   this.buf = buf;
@@ -167,33 +163,6 @@ SlidingBuffer.prototype.count = function() {
   return this.buf.length;
 };
 
-SlidingBuffer.prototype.close = noop;
-
-var PromiseBuffer = function PromiseBuffer() {
-  this.val = EMPTY;
-};
-
-PromiseBuffer.prototype.count = function() {
-  return (this.val === EMPTY) ? 0 : 1;
-};
-
-PromiseBuffer.prototype.add = function(item) {
-  if (this.val === EMPTY) {
-    this.val = item;
-  }
-};
-
-PromiseBuffer.prototype.is_full = function() {
-  return false;
-};
-
-PromiseBuffer.prototype.remove = function() {
-  return this.val;
-};
-
-PromiseBuffer.prototype.close = function() {
-  this.val = EMPTY;
-};
 
 var ring = exports.ring = function ring_buffer(n) {
   return new RingBuffer(0, 0, 0, new Array(n));
@@ -217,10 +186,6 @@ exports.dropping = function dropping_buffer(n) {
 
 exports.sliding = function sliding_buffer(n) {
   return new SlidingBuffer(ring(n), n);
-};
-
-exports.promise = function promise_buffer() {
-  return new PromiseBuffer();
 };
 
 exports.EMPTY = EMPTY;

--- a/src/impl/channels.js
+++ b/src/impl/channels.js
@@ -205,7 +205,6 @@ Channel.prototype.close = function() {
 
   // TODO: Duplicate code. Make a "_flush" function or something
   if (this.buf) {
-    this.buf.close();
     this.xform["@@transducer/result"](this.buf);
     while (true) {
       if (this.buf.count() === 0) {

--- a/test/buffers.js
+++ b/test/buffers.js
@@ -91,33 +91,3 @@ describe("Sliding buffer", function() {
     assert(buffers.EMPTY === b.remove(), "popping empty buffer gives EMPTY");
   });
 });
-
-describe("Promise buffer", function() {
-  it("should work", function() {
-    var b = buffers.promise();
-    assert.equal(b.count(), 0, "new buffer is empty");
-    assert.equal(b.remove(), buffers.EMPTY, "popping empty buffer gives EMPTY");
-
-    b.add("1");
-    assert.equal(b.count(), 1);
-
-    b.add("2");
-    assert.equal(b.count(), 1, "promise buffer drops puts after the first one");
-    assert.equal(b.is_full(), false, "promise buffer is never full");
-    assert.doesNotThrow(function() {
-      b.add("3");
-    }, "promise buffer always accepts push");
-    assert.equal(b.count(), 1);
-
-    assert.equal(b.remove(), "1", "promise buffer always returns oldest item");
-    assert.equal(b.is_full(), false);
-    assert.equal(b.count(), 1);
-
-    assert.equal(b.remove(), "1", "promise buffer keeps returning oldest item");
-    assert.equal(b.is_full(), false);
-    assert.equal(b.count(), 1);
-
-    b.close();
-    assert.equal(b.remove(), buffers.EMPTY, "promise buffer returns EMPTY after closing it");
-  });
-});


### PR DESCRIPTION
When taking from a promise channel before a value is delivered, the takers
will not see the delivered value. This is not the expected promise like
behavior.

For more information see https://github.com/clojure/core.async/commit/d073896192fa55fab992eb4c9ea57b86ec5cf076