### PR TITLE
Simplified module exports

### DIFF
--- a/src/chan.js
+++ b/src/chan.js
@@ -1,0 +1,15 @@
+const buffers = require('./impl/buffers');
+const channels = require('./impl/channels');
+
+module.exports = function chan(bufferOrNumber, xform, exHandler) {
+  let buf;
+  if (bufferOrNumber === 0) {
+    bufferOrNumber = null;
+  }
+  if (typeof bufferOrNumber === 'number') {
+    buf = buffers.fixed(bufferOrNumber);
+  } else {
+    buf = bufferOrNumber;
+  }
+  return channels.chan(buf, xform, exHandler);
+};

--- a/src/csp.core.js
+++ b/src/csp.core.js
@@ -1,66 +1,22 @@
-var buffers = require("./impl/buffers");
-var channels = require("./impl/channels");
-var select = require("./impl/select");
-var process = require("./impl/process");
-var timers = require("./impl/timers");
+const buffers = require('./impl/buffers');
 
-function spawn(gen, creator) {
-  var ch = channels.chan(buffers.fixed(1));
-  (new process.Process(gen, function(value) {
-    if (value === channels.CLOSED) {
-      ch.close();
-    } else {
-      process.put_then_callback(ch, value, function(ok) {
-        ch.close();
-      });
-    }
-  }, creator)).run();
-  return ch;
-};
+exports = module.exports = require('./impl/process');
 
-function go(f, args) {
-  args = args || [];
+exports.chan = require('./chan');
+exports.go = require('./go');
+exports.spawn = require('./spawn');
 
-  var gen = f.apply(null, args);
-  return spawn(gen, f);
-};
+// aliases
+exports.putAsync = exports.put_then_callback;
+exports.takeAsync = exports.take_then_callback;
 
-function chan(bufferOrNumber, xform, exHandler) {
-  var buf;
-  if (bufferOrNumber === 0) {
-    bufferOrNumber = null;
-  }
-  if (typeof bufferOrNumber === "number") {
-    buf = buffers.fixed(bufferOrNumber);
-  } else {
-    buf = bufferOrNumber;
-  }
-  return channels.chan(buf, xform, exHandler);
-};
+// expose data from other modules
+exports.CLOSED = require('./impl/channels').CLOSED;
+exports.DEFAULT = require('./impl/select').DEFAULT;
+exports.timeout = require('./impl/timers').timeout;
 
-
-module.exports = {
-  buffers: {
-    fixed: buffers.fixed,
-    dropping: buffers.dropping,
-    sliding: buffers.sliding
-  },
-
-  spawn: spawn,
-  go: go,
-  chan: chan,
-  DEFAULT: select.DEFAULT,
-  CLOSED: channels.CLOSED,
-
-  put: process.put,
-  take: process.take,
-  offer: process.offer,
-  poll: process.poll,
-  sleep: process.sleep,
-  alts: process.alts,
-  putAsync: process.put_then_callback,
-  takeAsync: process.take_then_callback,
-  NO_VALUE: process.NO_VALUE,
-
-  timeout: timers.timeout
+exports.buffers = {
+  fixed: buffers.fixed,
+  dropping: buffers.dropping,
+  sliding: buffers.sliding,
 };

--- a/src/csp.js
+++ b/src/csp.js
@@ -1,11 +1,8 @@
-"use strict";
+const pipeline = require('./csp.pipeline');
 
-var csp = require("./csp.core");
-var operations = require("./csp.operations");
-var pipeline = require('./csp.pipeline');
+exports = module.exports = require('./csp.core');
 
-csp.operations = operations;
-csp.operations.pipeline = pipeline.pipeline;
-csp.operations.pipelineAsync = pipeline.pipelineAsync;
+exports.operations = require('./csp.operations');
 
-module.exports = csp;
+exports.operations.pipeline = pipeline.pipeline;
+exports.operations.pipelineAsync = pipeline.pipelineAsync;

--- a/src/go.js
+++ b/src/go.js
@@ -1,0 +1,5 @@
+const spawn = require('./spawn');
+
+module.exports = function go(f, args = []) {
+  return spawn(f(...args), f);
+};

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -1,0 +1,17 @@
+const buffers = require('./impl/buffers');
+const channels = require('./impl/channels');
+const process = require('./impl/process');
+
+module.exports = function spawn(gen, creator) {
+  const ch = channels.chan(buffers.fixed(1));
+
+  (new process.Process(gen, (value) => {
+    if (value === channels.CLOSED) {
+      ch.close();
+    } else {
+      process.put_then_callback(ch, value, () => ch.close());
+    }
+  }, creator)).run();
+
+  return ch;
+};


### PR DESCRIPTION
* eslint'd
* pulled inline functions into their own files
* simplified the exports

## Notes

* It seems like `csp.core.js` is not very useful. The only purpose it is serving (that I can tell) is to make it so you can require one thing and access a lot of different modules' properties and methods.
* `csp.js` just adds more external properties and methods to `csp.core.js`
* It seems like there should be one of these convenience modules/loaders/files (`csp.js` and `csp.core.js`) instead of two if any at all.
* In `csp.core.js`, `buffers.EMPTY` is not exposed. I wasn't sure if that was intentional or not.