### PR TITLE
Fix prepublish doesn't include lib folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,16 @@
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+pids
+logs
+results
+npm-debug.log
+.idea
+.tern-port
+coverage
 flow

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-csp",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "CSP channels with ES6 generators, inspired by Clojurescript's core.async and Go",
   "keywords": [
     "csp",


### PR DESCRIPTION
This PR is to fix the problem of `npm publish` not including prebuild `lib` folder