### PR TITLE
Fix missing babel-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-csp",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "CSP channels with ES6 generators, inspired by Clojurescript's core.async and Go",
   "keywords": [
     "csp",
@@ -39,7 +39,6 @@
     "babel-plugin-transform-runtime": "^6.12.0",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-runtime": "^6.11.6",
     "chai": "^3.5.0",
     "chokidar-cli": "^1.2.0",
     "eslint": "^3.2.2",
@@ -63,6 +62,7 @@
     "webpack": "^2.1.0-beta.20"
   },
   "dependencies": {
+    "babel-runtime": "^6.11.6",
     "lodash": "^4.14.2"
   },
   "scripts": {


### PR DESCRIPTION
Fix missing babel-runtime dependencies when running in node environment