### PR TITLE
fix: empty query returns error object instead of array

### DIFF
--- a/examples/web/throttle.html
+++ b/examples/web/throttle.html
@@ -70,14 +70,18 @@
              csp.go(function*() {
                  for (;;) {
                      var query = yield csp.take(input);
-                     request(query);
-                     $display.addClass("waiting");
-                     var data = yield csp.take(result);
-                     $display.removeClass("waiting");
-                     $display.html("");
-                     data[1].forEach(function(item) {
-                         $("<div>").text(item).appendTo($display);
-                     });
+                     if (query.trim() !== '') {
+                         request(query);
+                         $display.addClass("waiting");
+                         var data = yield csp.take(result);
+                         $display.removeClass("waiting");
+                         $display.html("");
+                         data[1].forEach(function(item) {
+                             $("<div>").text(item).appendTo($display);
+                         });
+                     } else {
+                        $display.html("");
+                     }
                  }
              });
         </script>


### PR DESCRIPTION
in the demo throttle:
![image](https://cloud.githubusercontent.com/assets/449224/18375775/b2f471fc-768b-11e6-8d86-b3858b92d155.png)
