### PR TITLE
setSoloMode member function of mix fix, some @flows

### DIFF
--- a/src/csp.operations.js
+++ b/src/csp.operations.js
@@ -595,7 +595,7 @@ class Mix {
     this._changed();
   }
 
-  setSoloMode = function (mode) {
+  setSoloMode(mode) {
     if (VALID_SOLO_MODES.indexOf(mode) < 0) {
       throw new Error('Mode must be one of: ', VALID_SOLO_MODES.join(', '));
     }

--- a/src/impl/handlers.js
+++ b/src/impl/handlers.js
@@ -1,3 +1,4 @@
+// @flow
 import { Box } from './channels';
 
 export class FnHandler {

--- a/src/impl/instruction.js
+++ b/src/impl/instruction.js
@@ -1,3 +1,4 @@
+// @flow
 export default class Instruction<T> {
   static TAKE: string = 'take';
   static PUT: string = 'put';


### PR DESCRIPTION
I was trying to get rollup to work on js-csp and found these. Acorn doesn't like that function as is, and the plugin for rollup that removes flow syntax ignores files without the `@flow` tag. There's no solo mode test.