### PR TITLE
Release timers after closing timeout channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ npm-debug.log
 node_modules
 .idea
 .tern-port
+.vscode
 lib
 es
 build

--- a/src/impl/dispatch.js
+++ b/src/impl/dispatch.js
@@ -46,6 +46,10 @@ export function run(func: Function): void {
 
 export type TimeoutType = number | any;
 
-export function queueDelay(func: Function, delay: number): Timeout {
+export function queueDelay(func: Function, delay: number): TimeoutType {
   return setTimeout(func, delay);
+}
+
+export function removeDelay(timer: TimeoutType): void {
+  clearTimeout(timer);
 }

--- a/src/impl/dispatch.js
+++ b/src/impl/dispatch.js
@@ -44,6 +44,8 @@ export function run(func: Function): void {
   queueDispatcher();
 }
 
-export function queueDelay(func: Function, delay: number): void {
-  setTimeout(func, delay);
+export type TimeoutType = number | any;
+
+export function queueDelay(func: Function, delay: number): Timeout {
+  return setTimeout(func, delay);
 }

--- a/src/impl/timers.js
+++ b/src/impl/timers.js
@@ -1,11 +1,21 @@
 // @flow
+import type { TimeoutType } from './dispatch';
 import { queueDelay } from './dispatch';
-import { chan, Channel } from './channels';
+import { chan, Channel, CLOSED } from './channels';
+import { Process } from './process';
+
+export function* stopTakingOnClose(ch: Channel): Generator<*, *, *> {
+  while (CLOSED !== (yield ch)) ;
+}
+
+function releaseTimer(ch: Channel, timer: TimeoutType): Process {
+  const release = clearTimeout.bind(null, timer);
+  return new Process(stopTakingOnClose(ch), release, stopTakingOnClose);
+}
 
 export function timeout(msecs: number): Channel { // eslint-disable-line
   const ch: Channel = chan();
-
-  queueDelay(() => ch.close(), msecs);
-
+  const timer = queueDelay(() => ch.close(), msecs);
+  releaseTimer(ch, timer).run();
   return ch;
 }

--- a/test/timers.js
+++ b/test/timers.js
@@ -1,0 +1,24 @@
+/* eslint-disable require-yield */
+import mocha from 'mocha';
+import { assert } from 'chai';
+//import { it, beforeEach } from './../src/csp.test-helpers';
+import { stopTakingOnClose } from './../src/impl/timers';
+import { chan, go, put, operations, CLOSED } from './../src/csp';
+
+describe('Utils', () => {
+    describe('stopTakingOnClose', () => {
+        it('should terminate once input channel is closed', function(done) {
+            const ch = chan()
+            const tracker = go(stopTakingOnClose, [ch])
+            const assertClosed = () => {
+                assert.ok(ch.closed)
+                done()
+            }
+            go(function*() {
+                yield put(ch, true)
+                assertClosed(yield tracker)
+            })
+            ch.close()
+        })
+    })
+})

--- a/test/timers.js
+++ b/test/timers.js
@@ -1,24 +1,98 @@
 /* eslint-disable require-yield */
-import mocha from 'mocha';
 import { assert } from 'chai';
-//import { it, beforeEach } from './../src/csp.test-helpers';
-import { stopTakingOnClose } from './../src/impl/timers';
-import { chan, go, put, operations, CLOSED } from './../src/csp';
+import { queueDelay } from './../src/impl/dispatch';
+import { releaseTimerOnClose, stopTakingOnClose } from './../src/impl/timers';
+import { chan, go, spawn, take, put, alts, timeout, CLOSED } from './../src/csp';
 
-describe('Utils', () => {
-    describe('stopTakingOnClose', () => {
-        it('should terminate once input channel is closed', function(done) {
-            const ch = chan()
-            const tracker = go(stopTakingOnClose, [ch])
-            const assertClosed = () => {
-                assert.ok(ch.closed)
-                done()
-            }
-            go(function*() {
-                yield put(ch, true)
-                assertClosed(yield tracker)
-            })
-            ch.close()
-        })
-    })
-})
+const MS_10S = 1000 * 10;
+
+function assertTimerRunning(ch, timer) {
+  assert.notOk(ch.closed);
+  assert.notOk(timer._called);
+  assert.notEqual(timer._idleTimeout, -1);
+}
+
+function assertTimerReleased(ch, timer, done) {
+  assert.ok(ch.closed);
+  assert.notOk(timer._called);
+  assert.equal(timer._idleTimeout, -1);
+  done();
+}
+
+function* clientG(ch, ms) {
+  const gc = timeout(ms);
+  try {
+    yield gc;
+    yield put(ch, 42);
+  }
+  finally {
+    return gc.close(); // eslint-disable-line
+  }
+}
+
+function* resultG(ch, ms) {
+  const cancel = timeout(ms);
+  const result = yield alts([ch, cancel]);
+  return { result, cancel };
+}
+
+describe('Timers', () => {
+  describe('timeout', () => {
+    it('should close channel after specified timeout', (done) => {
+      const targetCh = chan();
+      const client = clientG(targetCh, MS_10S), resultP = resultG(targetCh, 0);
+      const clientCh = spawn(client), resultCh = spawn(resultP);
+      const assertCancelClosed = ({ result, cancel }) => {
+        assert.strictEqual(result.channel, cancel);
+        assert.ok(cancel.closed);
+      };
+      go(function* () {
+        assertCancelClosed(yield take(resultCh));
+        client.return(); //closes channel
+        yield clientCh;
+        done();
+      });
+    });
+    it('should use #releaseTimerOnClose handler for timer cleanup on channel close', (done) => {
+      const ll = Array.from({ length: 100 }, () => timeout(200));
+      go(function* closeWithPuts() {
+        for(let ch of ll) {
+          yield put(ch, 42);
+          yield timeout(0);
+          ch.close();
+          assert.equal(yield take(ch), CLOSED);
+          assert.ok(ch.closed);
+        }
+        done();
+      });
+    });
+  });
+  describe('releaseTimerOnClose (Node timers)', () => {
+    it('should release timer on channel close', (done) => {
+      const ch = chan();
+      const timer = queueDelay(() => ch.close(), MS_10S);
+      releaseTimerOnClose(ch, timer);
+      assertTimerRunning(ch, timer);
+      go(function* () {
+        yield ch;
+        assertTimerReleased(ch, timer, done);
+      });
+      ch.close();
+    });
+  });
+  describe('stopTakingOnClose', () => {
+    it('should keep polling input channel until closed', (done) => {
+      const ch = chan();
+      const tracker = go(stopTakingOnClose, [ch]);
+      const assertClosed = () => {
+        assert.ok(ch.closed);
+        done();
+      };
+      go(function* () {
+        yield put(ch, 42);
+        assertClosed(yield tracker);
+      });
+      ch.close();
+    });
+  });
+});


### PR DESCRIPTION
This fix releases timers by calling `clearTimeout` once timeout channels close. Code changes do not affect the API directly. Refer to #110 

Documentation is pending. Please comment on the issue.