### PR TITLE
export Channel type

### DIFF
--- a/src/csp.js
+++ b/src/csp.js
@@ -36,7 +36,7 @@ export const operations = {
   take: takeN,
 };
 export const buffers = { fixed, dropping, sliding, promise };
-export { CLOSED } from './impl/channels';
+export { CLOSED, Channel, } from './impl/channels';
 export { timeout } from './impl/timers';
 export { DEFAULT } from './impl/results';
 export {


### PR DESCRIPTION
Purpose: To check type of message on channel and handle it accordingly

```JavaScript
someChan.constructor === csp.chan().constructor //current
someChan instanceof Channel //proposed
```

#121 #122 
