### PR TITLE
Fix import path in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ node examples/go/pingpong
 ## Web
 Compile first by running
 ```bash
-npm run build:browser
+npm run build
 ```
 
 The Firebase example needs a real [Firebase](https://www.firebase.com) url, and works only in Firefox

--- a/examples/go/pingpong.js
+++ b/examples/go/pingpong.js
@@ -1,7 +1,7 @@
 'use strict'; // eslint-disable-line
 
 // http://talks.golang.org/2013/advconc.slide#6
-const csp = require('../../lib/csp');
+const csp = require('../../lib/js-csp');
 
 function* player(name, table) {
   for (;;) {
@@ -20,7 +20,7 @@ function* player(name, table) {
   }
 }
 
-csp.go(function* () {
+csp.go(function*() {
   const table = csp.chan();
 
   csp.go(player, ['ping', table]);

--- a/examples/web/firebase.html
+++ b/examples/web/firebase.html
@@ -26,7 +26,7 @@
                 </canvas>
             </div>
         </div>
-        <script type="text/javascript" src="../../build/csp.min.js"></script>
+        <script type="text/javascript" src="../../dist/js-csp.min.js"></script>
         <script src="https://cdn.firebase.com/js/client/2.1.1/firebase.js"></script>
         <script type="text/javascript;version=1.8">
              /* Put a real Firebase url here */

--- a/examples/web/mouse-events.html
+++ b/examples/web/mouse-events.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="UTF-8"></meta>
         <title>Events</title>
-        <script type="text/javascript" src="../../build/csp.min.js"></script>
+        <script type="text/javascript" src="../../dist/js-csp.min.js"></script>
     </head>
     <body>
         <div id="display"></div>

--- a/examples/web/throttle.html
+++ b/examples/web/throttle.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="UTF-8"></meta>
         <title>Events</title>
-        <script type="text/javascript" src="../../build/csp.min.js"></script>
+        <script type="text/javascript" src="../../dist/js-csp.min.js"></script>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
     </head>
     <body>


### PR DESCRIPTION
```
lib/csp => lib/js-csp
build/csp.min.js => dist/js-csp.min.js
```
Partially addresses #118 