### PR TITLE
initial frp examples

### DIFF
--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -17,9 +17,7 @@
         
         function fromEvent($element, eventName) {
           var outc = csp.chan();
-          csp.go(function* () {
-            $element.on(eventName, evt => { yield csp.put(outc, evt) });
-          });
+          $element.on(eventName, evt => { csp.putAsync(outc, evt) });
           return outc;
         }
 
@@ -102,7 +100,7 @@
             if (text.length > 2) {
               yield csp.put(longText, evt.key, () => undefined);
            }
-          }p
+          }
         });
 
         var debounced = debounce(longText, 500 /* ms */);

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -69,7 +69,6 @@ function skipDuplicates(inc, comparatorFn) {
   csp.go(function* () {
     while(true) {
       var next = yield csp.take(inc);
-      console.log(next);
       // always pipe out the first one
       if (init) {
         previous = next;

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -46,7 +46,7 @@
               // event) will reset the timeout.
               scheduler = setTimeout(   
                 function() {
-                  csp.putAsync(outc, next, () => undefined)
+                  csp.putAsync(outc, next);
                 },
                 timeout);
             }

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -14,31 +14,40 @@
         <input type="text" name="" value="" id="input" />
         <div id="output"></div>
         <script type="text/javascript">
-  /**
-   * Throttles inc channel by given amount of milliseconds, but so
-   * that event is only emitted after the given "quiet period". 
-   *  
-   * Example:
-   * ```
-   * inc:       asdf----asdf----
-   * debounce(inc,2): -----f-------f--
-   * ```
-   * @param {Channel} inc
-   * @param {Number} timout in ms
-   * @returns {Channel} debounced channel
-   */
-function* debounce(inc, timeout) {
+
+function fromEvent($element, eventName) {
+  var outc = csp.chan();
+  $element.on(eventName, evt => csp.putAsync(outc, evt, () => undefined));
+  return outc;
+}
+
+/**
+ * Throttles inc channel by given amount of milliseconds, but so
+ * that event is only emitted after the given "quiet period". 
+ *  
+ * Example:
+ * ```
+ * inc:       asdf----asdf----
+ * debounce(inc,2): -----f-------f--
+ * ```
+ * @param {Channel} inc
+ * @param {Number} timout in ms
+ * @returns {Channel} debounced channel
+ */
+function debounce(inc, timeout) {
   var scheduler
   var outc = csp.chan();
   csp.go(function* () {
     while(true) {
       var next = yield csp.take(inc);
-      scheduler && clearTimeout(scheduler);
+      clearTimeout(scheduler);
       // if nothing happens in the next timeout interval, then `next`
       // will be propagated. Otherwise, the above line (in the next
       // event) will reset the timeout.
-      scheduler = setTimeout(
-        function*() { yield csp.put(outc, next) },
+      scheduler = setTimeout(   
+        function() {
+          csp.putAsync(outc, next, () => undefined)
+        },
         timeout);
     }
   });
@@ -52,7 +61,7 @@ function* debounce(inc, timeout) {
  * @param {Function} comparatorFn
  * @returns {Channel}
  */
-function* skipDuplicates(inc, comparatorFn) {
+function skipDuplicates(inc, comparatorFn) {
   comparatorFn = comparatorFn || ((x,y) => x === y);
   var init = false;
   var previous = null;
@@ -60,6 +69,7 @@ function* skipDuplicates(inc, comparatorFn) {
   csp.go(function* () {
     while(true) {
       var next = yield csp.take(inc);
+      console.log(next);
       // always pipe out the first one
       if (init) {
         previous = next;
@@ -68,7 +78,7 @@ function* skipDuplicates(inc, comparatorFn) {
         continue;
       }
       // if they're not dupicates, then pipe to outc
-      if (!comparatorFn(next, prev)) {
+      if (!comparatorFn(next, previous)) {
         previous = next;
         yield csp.put(outc, next);
         continue;
@@ -79,27 +89,32 @@ function* skipDuplicates(inc, comparatorFn) {
 }
 
 var $input = $('#input');
-var $results = $('#results');
+var $output = $('#output');
 
-var keyups = csp.chan();
-/* Only get the value from each key up */
-$input.on('keyup', function*(evt) {
-  var text = evt.target.value;
-  if (text.length > 2) {
-    yield csp.putAsync(keyups, text); 
+var keyups = fromEvent($input, 'keyup');
+var longText = csp.chan(10);
+
+csp.go(function*() {
+  while(true) {
+    var evt = yield csp.take(keyups);
+    var text = evt.target.value;
+    if (text.length > 2) {
+      yield csp.put(longText, evt.key, () => undefined);
+   }
   }
-})
+});
 
-var debounced = debounce(keyups, 500 /* ms */);
-/* Now get only distinct values, so we eliminate the arrows and other control characters */
+var debounced = debounce(longText, 500 /* ms */);
 var distinct = skipDuplicates(debounced);
 
 csp.go(function* () {
+  var text = "";
   while(true) {
-    var text = yield csp.take(distinct);
-    $('output').val(text)
+    var ch = yield csp.take(distinct);
+    text += ch;
+    $output.text(text)
   }
-});
+ });
         </script>
     </body>
 </html>

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -11,6 +11,27 @@
              color: gray;
          }
         </style>
+        <h3>FRP Example</h3>
+        <h4>Demonstrates controling/transforming stream input</h4>
+        <ul>
+          <li>
+            Processes input text when total text is more than two characters.
+          </li>
+          <li>
+            Debounces key presses by 500ms i.e., it limits the rate it
+            processes key presses.
+          </li>
+          <li>
+            Skips duplicate key presses.
+          </li>
+          <li>
+            Example:
+            <pre>
+input:  abcd----efgh----
+output: -----d-------h--
+            </pre>
+          </li>
+        </ul>
         <input type="text" name="" value="" id="input" />
         <div id="output"></div>
         <script type="text/javascript">
@@ -27,8 +48,8 @@
          *  
          * Example:
          * ```
-         * inc:       asdf----asdf----
-         * debounce(inc,2): -----f-------f--
+         * inc:             abcd----efgh----
+         * debounce(inc,2): -----d-------h--
          * ```
          * @param {Channel} inc
          * @param {Number} timout in ms
@@ -91,20 +112,19 @@
         var $output = $('#output');
 
         var keyups = fromEvent($input, 'keyup');
-        var longText = csp.chan(10);
+        var longText = csp.chan();
+        var debounced = debounce(longText, 500 /* ms */);
+        var distinct = skipDuplicates(debounced);
 
         csp.go(function*() {
           while(true) {
             var evt = yield csp.take(keyups);
             var text = evt.target.value;
             if (text.length > 2) {
-              yield csp.put(longText, evt.key, () => undefined);
+              yield csp.put(longText, evt.key);
            }
           }
         });
-
-        var debounced = debounce(longText, 500 /* ms */);
-        var distinct = skipDuplicates(debounced);
 
         csp.go(function* () {
           var text = "";

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -1,0 +1,107 @@
+<html>
+    <head>
+        <meta charset="UTF-8"></meta>
+        <title>FRP</title>
+        <script type="text/javascript" src="../../dist/js-csp.es5.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
+    </head>
+    <body>
+        <style>
+         #display.waiting {
+             color: gray;
+         }
+        </style>
+        <input type="text" name="" value="" id="input" />
+        <div id="output"></div>
+        <script type="text/javascript">
+/**
+  * Throttles inc channel by given amount of milliseconds, but so
+  * that event is only emitted after the given "quiet period". 
+  *  
+  * Example:
+  * ```
+  * inc:             asdf----asdf----
+  * debounce(inc,2): -----f-------f--
+  * ```
+  * @param {Channel} inc
+  * @param {Number} timout in ms
+  * @returns {Channel} debounced channel
+  */
+function* debounce(inc, timeout) {
+  var scheduler
+  var outc = csp.chan();
+  csp.go(function* () {
+    while(true) {
+      var next = yield csp.take(inc);
+      scheduler && clearTimeout(scheduler);
+	    // if nothing happens in the next timeout interval, then `next`
+			// will be propagated. Otherwise, the above line (in the next
+			// event) will reset the timeout.
+			scheduler = setTimeout(
+				() => {
+					csp.put(outc, next);
+				},
+				timeout);
+		}
+	});
+	return outc;
+}
+
+/**
+  * Drops consecutive equal elements. If no comparator function is
+  * specified, uses ===.
+  * @param {Channel} inc
+  * @param {Function} comparatorFn
+  * @returns {Channel}
+  */
+function* skipDuplicates(inc, comparatorFn) {
+  comparatorFn = comparatorFn || ((x,y) => x === y);
+  var init = false;
+  var previous = null;
+  var outc = csp.chan();
+  csp.go(function* () {
+    while(true) {
+      var next = yield csp.take(inc);
+      // always pipe out the first one
+      if (init) {
+        previous = next;
+        init = true;
+        csp.put(outc, next);
+        continue;
+      }
+      // if they're not dupicates, then pipe to outc
+      if (!comparatorFn(next, prev)) {
+        previous = next;
+        csp.put(outc, next);
+        continue;
+      }
+    }
+  });
+  return outc;
+}
+
+var $input = $('#input');
+var $results = $('#results');
+
+var keyups = csp.chan();
+/* Only get the value from each key up */
+$input.on('keyup', evt => {
+	var text = evt.target.value;
+	if (text.length > 2) {
+		//			csp.put(keyups, text);	
+	}
+})
+
+var debounced = debounce(keyups, 500 /* ms */);
+/* Now get only distinct values, so we eliminate the arrows and other control characters */
+var distinct = skipDuplicates(debounced);
+
+csp.go(function*() {
+   while(true) {
+ 		var text = yield csp.take(distinct);
+ 		$('output').val(text)
+ 	}
+ });
+        </script>
+    </body>
+</html>

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -14,19 +14,19 @@
         <input type="text" name="" value="" id="input" />
         <div id="output"></div>
         <script type="text/javascript">
-/**
-  * Throttles inc channel by given amount of milliseconds, but so
-  * that event is only emitted after the given "quiet period". 
-  *  
-  * Example:
-  * ```
-  * inc:             asdf----asdf----
-  * debounce(inc,2): -----f-------f--
-  * ```
-  * @param {Channel} inc
-  * @param {Number} timout in ms
-  * @returns {Channel} debounced channel
-  */
+  /**
+   * Throttles inc channel by given amount of milliseconds, but so
+   * that event is only emitted after the given "quiet period". 
+   *  
+   * Example:
+   * ```
+   * inc:       asdf----asdf----
+   * debounce(inc,2): -----f-------f--
+   * ```
+   * @param {Channel} inc
+   * @param {Number} timout in ms
+   * @returns {Channel} debounced channel
+   */
 function* debounce(inc, timeout) {
   var scheduler
   var outc = csp.chan();
@@ -34,26 +34,24 @@ function* debounce(inc, timeout) {
     while(true) {
       var next = yield csp.take(inc);
       scheduler && clearTimeout(scheduler);
-	    // if nothing happens in the next timeout interval, then `next`
-			// will be propagated. Otherwise, the above line (in the next
-			// event) will reset the timeout.
-			scheduler = setTimeout(
-				() => {
-					csp.put(outc, next);
-				},
-				timeout);
-		}
-	});
-	return outc;
+      // if nothing happens in the next timeout interval, then `next`
+      // will be propagated. Otherwise, the above line (in the next
+      // event) will reset the timeout.
+      scheduler = setTimeout(
+        () => csp.put(outc, next),
+        timeout);
+    }
+  });
+  return outc;
 }
 
 /**
-  * Drops consecutive equal elements. If no comparator function is
-  * specified, uses ===.
-  * @param {Channel} inc
-  * @param {Function} comparatorFn
-  * @returns {Channel}
-  */
+ * Drops consecutive equal elements. If no comparator function is
+ * specified, uses ===.
+ * @param {Channel} inc
+ * @param {Function} comparatorFn
+ * @returns {Channel}
+ */
 function* skipDuplicates(inc, comparatorFn) {
   comparatorFn = comparatorFn || ((x,y) => x === y);
   var init = false;
@@ -86,10 +84,10 @@ var $results = $('#results');
 var keyups = csp.chan();
 /* Only get the value from each key up */
 $input.on('keyup', evt => {
-	var text = evt.target.value;
-	if (text.length > 2) {
-		csp.putAsync(keyups, text);	
-	}
+  var text = evt.target.value;
+  if (text.length > 2) {
+    csp.putAsync(keyups, text); 
+  }
 })
 
 var debounced = debounce(keyups, 500 /* ms */);
@@ -97,11 +95,11 @@ var debounced = debounce(keyups, 500 /* ms */);
 var distinct = skipDuplicates(debounced);
 
 csp.go(function*() {
-   while(true) {
- 		var text = yield csp.take(distinct);
- 		$('output').val(text)
- 	}
- });
+  while(true) {
+    var text = yield csp.take(distinct);
+    $('output').val(text)
+  }
+});
         </script>
     </body>
 </html>

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -88,7 +88,7 @@ var keyups = csp.chan();
 $input.on('keyup', evt => {
 	var text = evt.target.value;
 	if (text.length > 2) {
-		//			csp.put(keyups, text);	
+		csp.putAsync(keyups, text);	
 	}
 })
 

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="UTF-8"></meta>
         <title>FRP</title>
-        <script type="text/javascript" src="../../dist/js-csp.es5.min.js"></script>
+        <script type="text/javascript" src="../../dist/js-csp.min.js"></script>
         <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
     </head>
     <body>
@@ -38,7 +38,7 @@ function* debounce(inc, timeout) {
       // will be propagated. Otherwise, the above line (in the next
       // event) will reset the timeout.
       scheduler = setTimeout(
-        () => csp.put(outc, next),
+        function*() { yield csp.put(outc, next) },
         timeout);
     }
   });
@@ -64,13 +64,13 @@ function* skipDuplicates(inc, comparatorFn) {
       if (init) {
         previous = next;
         init = true;
-        csp.put(outc, next);
+        yield csp.put(outc, next);
         continue;
       }
       // if they're not dupicates, then pipe to outc
       if (!comparatorFn(next, prev)) {
         previous = next;
-        csp.put(outc, next);
+        yield csp.put(outc, next);
         continue;
       }
     }
@@ -83,10 +83,10 @@ var $results = $('#results');
 
 var keyups = csp.chan();
 /* Only get the value from each key up */
-$input.on('keyup', evt => {
+$input.on('keyup', function*(evt) {
   var text = evt.target.value;
   if (text.length > 2) {
-    csp.putAsync(keyups, text); 
+    yield csp.putAsync(keyups, text); 
   }
 })
 
@@ -94,7 +94,7 @@ var debounced = debounce(keyups, 500 /* ms */);
 /* Now get only distinct values, so we eliminate the arrows and other control characters */
 var distinct = skipDuplicates(debounced);
 
-csp.go(function*() {
+csp.go(function* () {
   while(true) {
     var text = yield csp.take(distinct);
     $('output').val(text)

--- a/examples/web/frp.html
+++ b/examples/web/frp.html
@@ -14,106 +14,108 @@
         <input type="text" name="" value="" id="input" />
         <div id="output"></div>
         <script type="text/javascript">
+        
+        function fromEvent($element, eventName) {
+          var outc = csp.chan();
+          csp.go(function* () {
+            $element.on(eventName, evt => { yield csp.put(outc, evt) });
+          });
+          return outc;
+        }
 
-function fromEvent($element, eventName) {
-  var outc = csp.chan();
-  $element.on(eventName, evt => csp.putAsync(outc, evt, () => undefined));
-  return outc;
-}
+        /**
+         * Throttles inc channel by given amount of milliseconds, but so
+         * that event is only emitted after the given "quiet period". 
+         *  
+         * Example:
+         * ```
+         * inc:       asdf----asdf----
+         * debounce(inc,2): -----f-------f--
+         * ```
+         * @param {Channel} inc
+         * @param {Number} timout in ms
+         * @returns {Channel} debounced channel
+         */
+        function debounce(inc, timeout) {
+          var scheduler
+          var outc = csp.chan();
+          csp.go(function* () {
+            while(true) {
+              var next = yield csp.take(inc);
+              clearTimeout(scheduler);
+              // if nothing happens in the next timeout interval, then `next`
+              // will be propagated. Otherwise, the above line (in the next
+              // event) will reset the timeout.
+              scheduler = setTimeout(   
+                function() {
+                  csp.putAsync(outc, next, () => undefined)
+                },
+                timeout);
+            }
+          });
+          return outc;
+        }
 
-/**
- * Throttles inc channel by given amount of milliseconds, but so
- * that event is only emitted after the given "quiet period". 
- *  
- * Example:
- * ```
- * inc:       asdf----asdf----
- * debounce(inc,2): -----f-------f--
- * ```
- * @param {Channel} inc
- * @param {Number} timout in ms
- * @returns {Channel} debounced channel
- */
-function debounce(inc, timeout) {
-  var scheduler
-  var outc = csp.chan();
-  csp.go(function* () {
-    while(true) {
-      var next = yield csp.take(inc);
-      clearTimeout(scheduler);
-      // if nothing happens in the next timeout interval, then `next`
-      // will be propagated. Otherwise, the above line (in the next
-      // event) will reset the timeout.
-      scheduler = setTimeout(   
-        function() {
-          csp.putAsync(outc, next, () => undefined)
-        },
-        timeout);
-    }
-  });
-  return outc;
-}
+        /**
+         * Drops consecutive equal elements. If no comparator function is
+         * specified, uses ===.
+         * @param {Channel} inc
+         * @param {Function} comparatorFn
+         * @returns {Channel}
+         */
+        function skipDuplicates(inc, comparatorFn) {
+          comparatorFn = comparatorFn || ((x,y) => x === y);
+          var init = false;
+          var previous = null;
+          var outc = csp.chan();
+          csp.go(function* () {
+            while(true) {
+              var next = yield csp.take(inc);
+              // always pipe out the first one
+              if (init) {
+                previous = next;
+                init = true;
+                yield csp.put(outc, next);
+                continue;
+              }
+              // if they're not dupicates, then pipe to outc
+              if (!comparatorFn(next, previous)) {
+                previous = next;
+                yield csp.put(outc, next);
+                continue;
+              }
+            }
+          });
+          return outc;
+        }
 
-/**
- * Drops consecutive equal elements. If no comparator function is
- * specified, uses ===.
- * @param {Channel} inc
- * @param {Function} comparatorFn
- * @returns {Channel}
- */
-function skipDuplicates(inc, comparatorFn) {
-  comparatorFn = comparatorFn || ((x,y) => x === y);
-  var init = false;
-  var previous = null;
-  var outc = csp.chan();
-  csp.go(function* () {
-    while(true) {
-      var next = yield csp.take(inc);
-      // always pipe out the first one
-      if (init) {
-        previous = next;
-        init = true;
-        yield csp.put(outc, next);
-        continue;
-      }
-      // if they're not dupicates, then pipe to outc
-      if (!comparatorFn(next, previous)) {
-        previous = next;
-        yield csp.put(outc, next);
-        continue;
-      }
-    }
-  });
-  return outc;
-}
+        var $input = $('#input');
+        var $output = $('#output');
 
-var $input = $('#input');
-var $output = $('#output');
+        var keyups = fromEvent($input, 'keyup');
+        var longText = csp.chan(10);
 
-var keyups = fromEvent($input, 'keyup');
-var longText = csp.chan(10);
+        csp.go(function*() {
+          while(true) {
+            var evt = yield csp.take(keyups);
+            var text = evt.target.value;
+            if (text.length > 2) {
+              yield csp.put(longText, evt.key, () => undefined);
+           }
+          }p
+        });
 
-csp.go(function*() {
-  while(true) {
-    var evt = yield csp.take(keyups);
-    var text = evt.target.value;
-    if (text.length > 2) {
-      yield csp.put(longText, evt.key, () => undefined);
-   }
-  }
-});
+        var debounced = debounce(longText, 500 /* ms */);
+        var distinct = skipDuplicates(debounced);
 
-var debounced = debounce(longText, 500 /* ms */);
-var distinct = skipDuplicates(debounced);
-
-csp.go(function* () {
-  var text = "";
-  while(true) {
-    var ch = yield csp.take(distinct);
-    text += ch;
-    $output.text(text)
-  }
- });
+        csp.go(function* () {
+          var text = "";
+          while(true) {
+            var ch =  yield csp.take(distinct);
+            text += ch;
+            $output.text(text)
+          }
+        });
         </script>
     </body>
 </html>


### PR DESCRIPTION
Connected to #133

<strike>Still a work in progress:</strike>

Feedback:
1. I have worked with generators before, namely `redux-saga`. However, this is the first time I'm actually writing code to consume generator functions. It is probably worth reminding users that generators won't work inside vanilla JS functions (like event callbacks)---that is, this is the boundary between `js-csp` and vanilla JS, and hence, the need for `putAsync`/`takeAsync` (or are these needed?) This is also needed by the `golang` folks, where these functions don't exist.
2. Error messages aren't always helpful. In part, this is caused by generator code. For example, `t.take is not a function` is not really helpful when the cause is using `take`/`put` inside a normal JS function. In this PR, I specially noticed that it was specially easy to make a mistake in one part of the pipeline but not have a clear idea where the breakage was.
3. Related to this is that it's very easy to introduce dead lock by forgetting to call `yield`, yet it's not always clear what the problem is. Not sure what can be done here... maybe there are tips to minimize this issue?
3. `debounce`/`skipDuplicates` probably should be made part of the core.
4. There's gotta be a better way to write examples. Having a giant HTML isn't ideal. We need the examples to be in a JS file, transpiled to ES5. (Also, not everyone is using a modern browser/node env, so you need to specify recommended browser).
